### PR TITLE
Use globals when running stimela scripts

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -190,6 +190,9 @@ def run(argv):
 
                 GLOBALS[key] = eval("{:s}('{:s}')".format(_type, value))
 
+    # Update global dictionary with contents of GLOBALS
+    _globals.update(GLOBALS)
+
     if args.ncores:
         utils.CPUS = args.ncores
 


### PR DESCRIPTION
Previously these did not appear to be used.