### PR TITLE
Fix and simplify argument handling

### DIFF
--- a/bin/stimela
+++ b/bin/stimela
@@ -27,4 +27,4 @@ if not os.path.exists(stimela.LOG_CABS):
     with open(stimela.LOG_CABS, "w") as std:
         pass
 
-stimela.main([a for a in sys.argv])
+stimela.main([a for a in sys.argv[1:]])


### PR DESCRIPTION
- As we're no longer dependent on sys.argv, strip out the first argv which is the script name.
- Simplify and correct argument handling.