### PR TITLE
Issue 45

### DIFF
--- a/stimela/cargo/base/casa/Dockerfile
+++ b/stimela/cargo/base/casa/Dockerfile
@@ -1,1 +1,6 @@
-FROM kernsuite/casa
+FROM kernsuite/casa:4.7
+COPY standards_amend.py /
+COPY southern_calibrators.txt /
+RUN apt-get update
+RUN apt-get -y install python-casacore
+RUN /standards_amend.py

--- a/stimela/cargo/base/casa/southern_calibrators.txt
+++ b/stimela/cargo/base/casa/southern_calibrators.txt
@@ -1,0 +1,37 @@
+// Coefficients for 
+// log(S) = a + b*log(f) +c*log(f)**2 + d*log(f)**3
+// S in Jy
+// f in MHz (Perley versions in GHz !!)
+//
+// Generally valid from 843MHz (SUMSS) to 20GHz (ATCA).
+// Some have data points from PAPER (145MHz)
+
+
+name=0056-001 epoch=2016 ra=00h59m05.5s dec=+00d06m52s a=-0.9051 b=1.8362 c=-0.6141 d=0.0518
+name=0201-440 epoch=2016 ra=02h03m40.8s dec=-43d49m52s a=1.4053 b=0.1893 c=-0.1654 d=0.0030
+name=0237-233 epoch=2016 ra=02h40m08.2s dec=-23d09m16s a=-23.5170 b=20.5047 c=-5.5855 d=0.4851
+name=0252-712 epoch=2016 ra=02h52m46.1s dec=-71d04m35s a=1.1245 b=0.7190 c=-0.2955 d=0.0096
+name=CTA21    epoch=2016 ra=03h18m57.8s dec=+16d28m33s a=-13.4672 b=12.4587 c=-3.4110 d=0.2867
+name=0320+053 epoch=2016 ra=03h23m20.3s dec=+05d34m12s a=-6.9043 b=7.8471 c=-2.4713 d=0.2296
+name=0403-132 epoch=2016 ra=04h05m34.0s dec=-13d08m14s a=-0.8395 b=2.4438 c=-0.9451 d=0.1006
+name=0408-658 epoch=2016 ra=04h08m20.4s dec=-65d45m09s a=-0.9790 b=3.3662 c=-1.1216 d=0.0861
+name=0410-752 epoch=2016 ra=04h08m48.5s dec=-75d07m19s a=8.1443 b=-5.2122 c=1.4472 d=-0.1584
+name=0420-625 epoch=2016 ra=04h20m56.0s dec=-62d23m40s a=4.7772 b=-2.1190 c=0.3788 d=-0.0433
+name=0531+194 epoch=2016 ra=05h34m44.5s dec=+19d27m22s a=-3.4915 b=5.0261 c=-1.6476 d=0.1549
+name=0823-500 epoch=2016 ra=08h25m26.9s dec=-50d10m38s a=-33.5795 b=27.9753 c=-7.3670 d=0.6198
+name=0906-682 epoch=2016 ra=09h06m52.4s dec=-68d29m40s a=0.7680 b=1.3416 c=-0.6601 d=0.0573
+name=3C237    epoch=2016 ra=10h08m00.0s dec=+07d30m16s a=3.1549 b=-1.0771 c=0.2183 d=-0.0356
+name=1127-145 epoch=2016 ra=11h30m07.0s dec=-14d49m27s a=-4.7962 b=4.3260 c=-1.0387 d=0.0710
+name=1139-285 epoch=2016 ra=11h41m34.5s dec=-28d50m52s a=0.7452 b=1.2832 c=-0.6408 d=0.0632
+name=1151-348 epoch=2016 ra=11h54m21.8s dec=-35d05m29s a=-2.9686 b=3.9700 c=-1.2009 d=0.1020
+name=1240-209 epoch=2016 ra=12h43m12.3s dec=-21d12m13s a=5.2689 b=-4.0352 c=1.2650 d=-0.1561
+name=3C283    epoch=2016 ra=13h11m40.1s dec=-22d17m04s a=-3.3516 b=6.4132 c=-2.4230 d=0.2522
+name=1421-490 epoch=2016 ra=14h24m32.2s dec=-49d13m50s a=6.0550 b=-4.1963 c=1.1975 d=-0.1218
+name=1740-517 epoch=2016 ra=17h44m25.4s dec=-51d44m44s a=-3.6941 b=2.7447 c=-0.3655 d=-0.0153
+name=1827-360 epoch=2016 ra=18h30m58.8s dec=-36d02m30s a=0.4218 b=1.4761 c=-0.4243 d=0.0002
+name=1830-210 epoch=2016 ra=18h33m39.9s dec=-21d03m40s a=-6.2117 b=6.0429 c=-1.6037 d=0.1333
+name=1921-293 epoch=2016 ra=19h24m51.0s dec=-29d14m30s a=3.0213 b=-2.2634 c=0.7651 d=-0.0800
+name=1938-155 epoch=2016 ra=19h41m15.1s dec=-15d24m31s a=-2.1724 b=4.1589 c=-1.4511 d=0.1368
+name=2203-188 epoch=2016 ra=22h06m10.4s dec=-18d35m39s a=2.1847 b=-0.7118 c=0.1563 d=-0.0215
+name=3C446    epoch=2016 ra=22h25m47.2s dec=-04d57m01s a=3.8594 b=-1.8462 c=0.3468 d=-0.0192
+name=CTA102   epoch=2016 ra=22h32m36.4s dec=+11d43m51s a=-2.0888 b=2.9478 c=-0.9102 d=0.0855

--- a/stimela/cargo/base/casa/standards_amend.py
+++ b/stimela/cargo/base/casa/standards_amend.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+from pyrap.tables import table as tbl
+from pyrap import tables as tbls
+import re
+import numpy as np
+
+with open("/southern_calibrators.txt") as f, \
+     tbl("/casa-release-4.7.0-el6/data/nrao/VLA/standards/fluxcalibrator.data", readonly=False) as fc, \
+     tbl("/casa-release-4.7.0-el6/data/nrao/VLA/standards/PerleyButler2013Coeffs", readonly=False) as pb:
+    line=f.readline()
+    ln_no = 1
+    while line:
+        #discard comments
+        command = line.split("//")[0]
+
+        #empty line ?
+        if command.strip() == "":
+            print "Skipping line: '%s'" % line
+            line = f.readline()
+            ln_no += 1
+            continue
+
+        #source ?
+        valset = re.match(r"^name=(?P<name>[0-9A-Za-z\-+_]+)[ ]+"
+                          r"epoch=(?P<epoch>[0-9]+)[ ]+"
+                          r"ra=(?P<ra>[+\-]?[0-9]+h[0-9]+m[0-9]+(?:.[0-9]+)?s)[ ]+"
+                          r"dec=(?P<decl>[+\-]?[0-9]+d[0-9]+m[0-9]+(?:.[0-9]+)?s)[ ]+"
+                          r"a=(?P<a>[+\-]?[0-9]+(?:.[0-9]+)?)[ ]+"
+                          r"b=(?P<b>[+\-]?[0-9]+(?:.[0-9]+)?)[ ]+"
+                          r"c=(?P<c>[+\-]?[0-9]+(?:.[0-9]+)?)[ ]+"
+                          r"d=(?P<d>[+\-]?[0-9]+(?:.[0-9]+)?)$", 
+                          command)
+        #else illegal
+        if not valset:
+            raise RuntimeError("Illegal line encountered "
+                               "at line %d:'%s'" % (ln_no, line))
+
+        # parse sources (spectra in MHz) 
+        name = valset.group("name")
+        epoch = int(valset.group("epoch"))
+        ra = valset.group("ra")
+        valset_ra = re.match(r"^(?P<h>[+\-]?[0-9]+)h"
+                             r"(?P<m>[0-9]+)m"
+                             r"(?P<s>[0-9]+(?:.[0-9]+)?)s$",
+                             ra)
+        ra = np.deg2rad((float(valset_ra.group("h")) +
+                         float(valset_ra.group("m")) / 60.0 +
+                         float(valset_ra.group("s")) / 3600) / 24.0 * 360)
+        decl = valset.group("decl")
+        valset_decl = re.match(r"^(?P<d>[+\-]?[0-9]+)d"
+                               r"(?P<m>[0-9]+)m"
+                               r"(?P<s>[0-9]+(?:.[0-9]+)?)s$",
+                               decl)
+        decl = np.deg2rad(float(valset_decl.group("d")) + \
+                          float(valset_decl.group("m")) + \
+                          float(valset_decl.group("s")))
+
+        a = float(valset.group("a"))
+        b = float(valset.group("b"))
+        c = float(valset.group("c"))
+        d = float(valset.group("d"))
+        
+        # convert models to Perley Butler GHz format
+        k = np.log10(1000)
+        a1 = a + (b * k) + (c * k ** 2) + (d * k ** 3)
+        b1 = b + (2 * c * k) + (3 * d * k ** 2)
+        c1 = c + (3 * d * k)
+        d1 = d
+
+        print "Adding %s\t%d\t%3.2f\t%3.2f\t%.4f\t%.4f\t%.4f\t%.4f" % \
+            (name, epoch, ra, decl, a1, b1, c1, d1)
+
+        # append to standards table
+        fc.addrows()
+        fc.putcell("Name", fc.nrows() - 1, name)
+        fc.putcell("RA_J2000", fc.nrows() - 1, ra)
+        fc.putcell("Dec_J2000", fc.nrows() - 1, decl)
+        fc.putcell("AltNames", fc.nrows() - 1, np.array([[name]]))
+
+        coeffs = tbls.makearrcoldesc(name + "_coeffs", 
+                                     None,
+                                     ndim = 1,
+                                     shape = [4],
+                                     valuetype="float")
+        coefferrs = tbls.makearrcoldesc(name + "_coefferrs", 
+                                        None,
+                                        ndim = 1,
+                                        shape = [4],
+                                        valuetype="float")
+        pb.addcols(coeffs)
+        pb.addcols(coefferrs)
+        pb.putcol(name + "_coeffs",
+                  np.tile(np.array([a1, b1, c1, d1], 
+                                   dtype=np.float32),
+                          (pb.nrows(), 1)))
+        pb.putcol(name + "_coefferrs",
+                  np.tile(np.array([0, 0, 0, 0], 
+                                   dtype=np.float32),
+                          (pb.nrows(), 1)))
+
+        # finally parse next line
+        line = f.readline()
+        ln_no += 1
+
+
+

--- a/stimela/cargo/cab/autoflagger/src/run.py
+++ b/stimela/cargo/cab/autoflagger/src/run.py
@@ -20,7 +20,7 @@ msname = " ".join( ["%s/%s"%(MSDIR , ms)  for ms in msname] )
 strategy = jdict.pop("strategy", None)
 if strategy:
     strategy = utils.substitute_globals(strategy) or INPUT + "/" + strategy
-strategy = "-strategy %s/%s"%(INPUT, strategy) if strategy else ""
+strategy = "-strategy %s"%(strategy) if strategy else ""
 
 flag_cmd = ["-%s %s"%(a, "" if isinstance(b, bool) else b) for a,b in jdict.iteritems()] or [""]
 utils.xrun("aoflagger", flag_cmd+[strategy, msname])

--- a/stimela/cargo/configs/h5toms_params.json
+++ b/stimela/cargo/configs/h5toms_params.json
@@ -1,9 +1,10 @@
 {
     "blank-ms" : "/var/kat/static/blank.ms",
-    "full_pol" : true,
+    "full_pol" : false,
     "dumptime" : 0.0,
     "chanbin"  : 0,
     "flag_av"  : false,
     "output-ms" : "output.ms",
-    "hdf5files" : []
+    "hdf5files" : [],
+    "model-data" : false
 }


### PR DESCRIPTION
This adds the latest set of southern calibrators to the Stimela CASA base. SetJy should detect these automagically now (testing in progress). I've converted Tony Foley's spectra fits from MHz to Perley Butler GHz format:
log10(Brightness(freq) = a + b * log10(freq) + c * log10(freq) ** 2 + d * log10(freq) ** 3, where freq is in MHz
using the following MHz -> GHz conversion formulae:
k := np.log10(1000)
a1 = a + (b * k) + (c * k ** 2) + (d * k ** 3)
b1 = b + (2 * c * k) + (3 * d * k ** 2)
c1 = c + (3 * d * k)
d1 = d

I also made it simple to add new sources / update coefficients since the list itself is a work in progress.
@SpheMakh please review