### PR TITLE
Improve katdal custom dockerfile

### DIFF
--- a/stimela/cargo/base/katdal/Dockerfile
+++ b/stimela/cargo/base/katdal/Dockerfile
@@ -2,10 +2,6 @@ FROM stimela/base:0.2.7
 MAINTAINER <sphemakh@gmail.com>
 
 ENV PACKAGES \
-    software-properties-common \
-    python-software-properties \
-    python-pip \
-    git \
     build-essential \
     cmake \
     gfortran \
@@ -41,9 +37,6 @@ RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-reco
     make install && \
     cd / && \
     rm -rf /src
-
-# Install pyyaml
-RUN pip install pyyaml
 
 # Install custom branch of python-casacore
 RUN pip install git+https://github.com/sjperkins/python-casacore.git@create-default-ms#egg=python-casacore

--- a/stimela/cargo/base/katdal/Dockerfile
+++ b/stimela/cargo/base/katdal/Dockerfile
@@ -29,7 +29,7 @@ RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-reco
     mkdir -p /src/casacore/build && \
     cd /src/casacore/build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
-    make -j 8 && \
+    make && \
     make install && \
     cd / && \
     rm -rf /src

--- a/stimela/cargo/base/katdal/Dockerfile
+++ b/stimela/cargo/base/katdal/Dockerfile
@@ -21,12 +21,8 @@ ENV PACKAGES \
     libpython3.5-dev \
     libpython2.7-dev
 
-# enable universe, multiverse, restricted with world wide mirrors
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y $PACKAGES && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Install packages
+RUN docker-apt-install $PACKAGES
 
 # Install custom branch of casacore
 RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-record-to-tabledesc-static-members /src/casacore && \


### PR DESCRIPTION
Three changes

- Remove unnecessary packages that are already installed in base images
- Use docker-apt to abstract the install away
- Don't use parallel `make -j 8` to compile custom casacore. This likely breaks docker hubs 2GB [limit](http://stackoverflow.com/questions/31158913/is-there-any-limit-on-pull-number-in-docker-hub).