### PR TITLE
Fixing specfit cab

### DIFF
--- a/stimela/cargo/cab/specfit/src/addSPI.py
+++ b/stimela/cargo/cab/specfit/src/addSPI.py
@@ -26,25 +26,23 @@ def fitsInfo(fitsname = None):
     ndim = hdr["NAXIS"]
     imslice = np.zeros(ndim, dtype=int).tolist()
     imslice[-2:] = slice(None), slice(None)
-    
     image = hdu[0].data[imslice]
     wcs = WCS(hdr,mode='pyfits')
 
     return {'image':image,'wcs':wcs,'ra':ra,'dec':dec,'dra':dra,'ddec':ddec,'raPix':raPix,'decPix':decPix,'freq0':freq0}
 
-def sky2px(wcs,ra,dec,dra,ddec,cell):
+def sky2px(wcs,ra,dec,dra,ddec,cell, beam):
     """convert a sky region to pixel positions"""
-    beam =  3.971344894833e-03 # beam size, 
     dra = beam if dra<beam else dra # assume every source is at least as large as the psf
     ddec = beam if ddec<beam else ddec
     offsetDec = (ddec/2.)/cell
-    offsetRA = (dra/2.)/cell 
+    offsetRA = (dra/2.)/cell
     raPix,decPix = wcs.wcs2pix(ra,dec)
     return np.array([int(raPix-offsetRA),int(raPix+offsetRA),int(decPix-offsetDec),int(decPix+offsetDec)])
 
 def RemoveSourcesWithoutSPI(lsmname_in, lsmname_out):
-    model = Tigger.load(lsmname_in) 
-    sources = [src for src in model.sources]    
+    model = Tigger.load(lsmname_in)
+    sources = [src for src in model.sources]
     for src in sources:
         if not src.spectrum:
             model.sources.remove(src)
@@ -60,7 +58,7 @@ def CombineSourcesInCluster(lsmname_in, lsmname_out):
             cluster_sources[max_flux_index].flux.I = sum([src1.flux.I for src1 in cluster_sources])
         for src2 in cluster_sources:
             if src2 is not cluster_sources[max_flux_index]:
-                model.sources.remove(src2) 
+                model.sources.remove(src2)
         cluster_sources[max_flux_index].cluster_size=1
     model.save(lsmname_out)
 
@@ -68,7 +66,8 @@ def rad2arcsec(x):
     return x*3600.0*180.0/np.pi
 
 
-def addSPI(fitsname_alpha=None, fitsname_alpha_error=None, lsmname=None, outfile=None, freq0=None, beam=None, spitol=(-10,10)):
+def addSPI(fitsname_alpha=None, fitsname_alpha_error=None, lsmname=None,
+           outfile=None,freq0=None, beam=None, spitol=(-10,10)):
     """
         Add spectral index to a tigger lsm from a spectral index map (fits format)
         takes in a spectral index map, input lsm and output lsm name.
@@ -82,7 +81,7 @@ def addSPI(fitsname_alpha=None, fitsname_alpha_error=None, lsmname=None, outfile
     fits_alpha = fitsInfo(fitsname_alpha)    # Get fits info
     image_alpha = fits_alpha['image']     # get image data
 
-    if fitsname_alpha_error:   
+    if fitsname_alpha_error:
         fits_alpha_error = fitsInfo(fitsname_alpha_error)
         image_alpha_error = fits_alpha_error['image']
     else:
@@ -97,17 +96,21 @@ def addSPI(fitsname_alpha=None, fitsname_alpha_error=None, lsmname=None, outfile
     else:
         freq0 = freq0 or fits_alpha['freq0']
 
-    model = Tigger.load(lsmname)    # load sky model
+    model = Tigger.load(outfile)    # load output sky model
     rad = lambda a: a*(180/np.pi) # convert radians to degrees
 
-    for src in model.sources: 
+    for src in model.sources:
         ra = rad(src.pos.ra)
         dec = rad(src.pos.dec)
 
-        if np.sqrt((ra-fits_alpha["ra"])**2 + (dec-fits_alpha["dec"])**2)>tol: # exclude sources within {tol} of phase centre
-            dra = rad(src.shape.ex) if src.shape  else beam # cater for point sources
-            ddec = rad(src.shape.ex) if src.shape  else beam # assume source extent equal to the Gaussian major axis along both ra and dec axes
-            rgn = sky2px(fits_alpha["wcs"],ra,dec,dra,ddec,fits_alpha["dra"]) # Determine region of interest
+        # Include sources within {tol} of beam major axis i.e. beam = (bmin, bmaj)
+        if np.sqrt((ra-fits_alpha["ra"])**2 + (dec-fits_alpha["dec"])**2)<beam[1]:
+            # Cater for point sources and assume source extent equal to the
+            # Gaussian major axis along both ra and dec axis
+            dra = rad(src.shape.ex) if src.shape  else beam[0]
+            ddec = rad(src.shape.ex) if src.shape  else beam[1]
+            # Determine region of interest
+            rgn = sky2px(fits_alpha["wcs"],ra,dec,dra,ddec,fits_alpha["dra"], beam[1])
 
             imslice = slice(rgn[2], rgn[3]), slice(rgn[0], rgn[3])
             alpha = image_alpha[imslice]
@@ -125,16 +128,18 @@ def addSPI(fitsname_alpha=None, fitsname_alpha_error=None, lsmname=None, outfile
 
             if len(subIm_weighted)>0:
                 subIm_normalization = np.sum(subIm_weight)
-
                 spi = float(np.sum(subIm_weighted)/subIm_normalization)
+                spi_error = 1/float(subIm_normalization)
                 if spi > spitol[0] or spi < spitol[-1]:
-                    sys.stdout.write("INFO: Adding spi: %.3f (at %.3g MHz) to source %s"%(spi, freq0/1e6, src.name))
+                    sys.stdout.write("INFO: Adding spi: %.3f (at %.3g MHz) to source %s" % (
+                                     spi, freq0/1e6, src.name))
                     src.spectrum = Tigger.Models.ModelClasses.SpectralIndex(spi, freq0)
+                    src.setAttribute('spi_error', spi_error)
             else:
-                sys.stdout.write("ALERT: no spi info found in %s for source %s"%(fitsname_alpha, src.name))
+                sys.stdout.write("ALERT: no spi info found in %s for source %s" % (
+                                 fitsname_alpha, src.name))
         else:
             sys.stdout.write("ALERT: All SPI pixels are outside the tolerance range")
-
 
     model.save(outfile)
 
@@ -143,4 +148,4 @@ if __name__=="__main__":
     #fitsname_alpha_error = sys.argv[2]
     lsmname = sys.argv[2]
     outfile = sys.argv[3]
-    addSPI(fitsname_alpha, None, lsmname, outfile) 
+    addSPI(fitsname_alpha, None, lsmname, outfile)

--- a/stimela/cargo/cab/specfit/src/run.py
+++ b/stimela/cargo/cab/specfit/src/run.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import re
-import astropy.io.fits as fitsio
+import pyfits
 from pyrap.tables import table
 
 sys.path.append("/utils")
@@ -43,5 +43,12 @@ else:
 if lsmname and outlsm:
     sys.stdout.write("Extracting spi from image")
 
+    with pyfits.open(image) as hdu:
+        header = hdu[0].header
+        bmin = header['BMIN']
+        bmaj = header['BMAJ']
+    beam = (bmin, bmaj)
+
     import addSPI
-    addSPI.addSPI(spi_image, spi_err, lsmname, outlsm or lsmname, freq0=freq0, spitol=tol)
+    addSPI.addSPI(spi_image, spi_err, lsmname, outlsm or lsmname,
+                  beam=beam, freq0=freq0, spitol=tol)


### PR DESCRIPTION
Replaced hardcoded beam and tol measures by ones obtained from the image header.
Also the output model sources are tagged with spi error if spi was added.