### PR TITLE
Depend on bleeding edge KATDAL

### DIFF
--- a/stimela/cargo/base/katdal/Dockerfile
+++ b/stimela/cargo/base/katdal/Dockerfile
@@ -23,19 +23,24 @@ ENV PACKAGES \
 
 # Install packages
 RUN docker-apt-install $PACKAGES
+RUN docker-apt-install python-casacore
+RUN pip install git+https://github.com/ska-sa/katdal.git@single_pol
+RUN docker-apt-install wget
+RUN wget https://raw.githubusercontent.com/ska-sa/katdal/master/blank.ms.tgz
+RUN mkdir /var/kat && mkdir /var/kat/static && tar -xvf blank.ms.tgz -C /var/kat/static/
 
-# Install custom branch of casacore
-RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-record-to-tabledesc-static-members /src/casacore && \
-    mkdir -p /src/casacore/build && \
-    cd /src/casacore/build && \
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
-    make && \
-    make install && \
-    cd / && \
-    rm -rf /src
-
-# Install custom branch of python-casacore
-RUN pip install git+https://github.com/sjperkins/python-casacore.git@create-default-ms#egg=python-casacore
-
-# Install custom branch of katdal
-RUN pip  install git+https://github.com/sjperkins/katdal.git@use-python-casacore-ms-creation#egg=katdal
+## Install custom branch of casacore
+#RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-record-to-tabledesc-static-members /src/casacore && \
+#    mkdir -p /src/casacore/build && \
+#    cd /src/casacore/build && \
+#    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
+#    make && \
+#    make install && \
+#    cd / && \
+#    rm -rf /src
+#
+## Install custom branch of python-casacore
+#RUN pip install git+https://github.com/sjperkins/python-casacore.git@create-default-ms#egg=python-casacore
+#
+## Install custom branch of katdal
+#RUN pip  install git+https://github.com/sjperkins/katdal.git@use-python-casacore-ms-creation#egg=katdal

--- a/stimela/cargo/cab/h5toms/parameters.json
+++ b/stimela/cargo/cab/h5toms/parameters.json
@@ -70,16 +70,10 @@
             "name": "stop-w"
         }, 
         {
-            "info": "Produce a Stokes I MeasurementSet using only HH", 
-            "dtype": "bool", 
-            "default": false, 
-            "name": "HH"
-        }, 
-        {
-            "info": "Produce a Stokes I MeasurementSet using only VV", 
-            "dtype": "bool", 
-            "default": false, 
-            "name": "VV"
+            "info": "Select polarization products to include in MS from HH,VV,HV,VH is all available from HH,VV", 
+            "dtype": "str", 
+            "default": "HH,VV", 
+            "name": "pols-to-use"
         }, 
         {
             "info": "Print command to convert MS to miriad uvfits in casapy", 


### PR DESCRIPTION
- Removes building @sjperkins' fixed-width column MS branch, since we need the
  latest bleeding edge branch of katdal that supports outputing single
  correlation products. Fall back to KERN casacore.