### PR TITLE
Update h5toms parameters for katdal single polarisation mode

### DIFF
--- a/stimela/cargo/cab/h5toms/parameters.json
+++ b/stimela/cargo/cab/h5toms/parameters.json
@@ -1,138 +1,132 @@
 {
-    "task": "h5toms", 
-    "base": "stimela/katdal", 
-    "tag": "0.2.8", 
-    "description": "Convert HDF5 file(s) to MeasurementSet", 
-    "prefix": "--", 
-    "binary": "h5toms.py", 
-    "msdir": "true", 
+    "task": "h5toms",
+    "base": "stimela/katdal",
+    "tag": "0.2.8",
+    "description": "Convert HDF5 file(s) to MeasurementSet",
+    "prefix": "--",
+    "binary": "h5toms.py",
+    "msdir": "true",
     "parameters": [
         {
-            "info": "HDF5 file(s)", 
-            "name": "hdf5files", 
-            "io": "input", 
-            "default": null, 
-            "dtype": "list:file", 
+            "info": "HDF5 file(s)",
+            "name": "hdf5files",
+            "io": "input",
+            "default": null,
+            "dtype": "list:file",
             "required": true
-        }, 
+        },
         {
-            "info": "Blank MS used as template", 
-            "check_io": false, 
-            "name": "blank-ms", 
-            "io": "input", 
-            "default": "/var/kat/static/blank.ms", 
+            "info": "Blank MS used as template",
+            "check_io": false,
+            "name": "blank-ms",
+            "io": "input",
+            "default": "/var/kat/static/blank.ms",
             "dtype": "file"
-        }, 
+        },
         {
-            "info": "Output MS", 
-            "check_io": false, 
-            "name": "output-ms", 
-            "io": "msfile", 
-            "default": null, 
-            "dtype": "file", 
+            "info": "Output MS",
+            "check_io": false,
+            "name": "output-ms",
+            "io": "msfile",
+            "default": null,
+            "dtype": "file",
             "required": true
-        }, 
+        },
         {
-            "info": "Produce quad circular polarisation. (RR, RL, LR, LL) *** Currently just relabels the linear pols ****", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "Produce quad circular polarisation. (RR, RL, LR, LL) *** Currently just relabels the linear pols ****",
+            "dtype": "bool",
+            "default": false,
             "name": "circular"
-        }, 
+        },
         {
-            "info": "Reference antenna (default is first one used by script)", 
-            "dtype": "str", 
-            "default": null, 
+            "info": "Reference antenna (default is first one used by script)",
+            "dtype": "str",
+            "default": null,
             "name": "ref-ant"
-        }, 
+        },
         {
-            "info": "Tar-ball the MS", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "Tar-ball the MS",
+            "dtype": "bool",
+            "default": false,
             "name": "tar"
-        }, 
+        },
         {
-            "info": "Produce a full polarisation MS in CASA canonical order (HH, HV, VH, VV). Default is to produce HH,VV only", 
-            "dtype": "bool", 
-            "default": true, 
-            "name": "full-pol", 
+            "info": "Produce a full polarisation MS in CASA canonical order (HH, HV, VH, VV). Default is to produce HH,VV only",
+            "dtype": "bool",
+            "default": true,
+            "name": "full-pol",
             "mapping": "full_pol"
-        }, 
+        },
         {
-            "info": "More verbose progress information", 
-            "dtype": "bool", 
-            "default": true, 
+            "info": "More verbose progress information",
+            "dtype": "bool",
+            "default": true,
             "name": "verbose"
-        }, 
+        },
         {
-            "info": "Use W term to stop fringes for each baseline", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "Use W term to stop fringes for each baseline",
+            "dtype": "bool",
+            "default": false,
             "name": "stop-w"
-        }, 
+        },
         {
-            "info": "Produce a Stokes I MeasurementSet using only HH", 
-            "dtype": "bool", 
-            "default": false, 
-            "name": "HH"
-        }, 
+            "info": "Select polarisation products to include in MS from HH,VV,HV,VH, default is all available from HH,VV",
+            "dtype": "str",
+            "default": null,
+            "name": "pols-to-use"
+        },
         {
-            "info": "Produce a Stokes I MeasurementSet using only VV", 
-            "dtype": "bool", 
-            "default": false, 
-            "name": "VV"
-        }, 
-        {
-            "info": "Print command to convert MS to miriad uvfits in casapy", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "Print command to convert MS to miriad uvfits in casapy",
+            "dtype": "bool",
+            "default": false,
             "name": "uvfits"
-        }, 
+        },
         {
-            "info": "MeasurementSet will exclude autocorrelation data", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "MeasurementSet will exclude autocorrelation data",
+            "dtype": "bool",
+            "default": false,
             "name": "no-auto"
-        }, 
+        },
         {
-            "info": "Range of frequency channels to keep (zero-based inclusive 'first_chan,last_chan', default is all channels)", 
-            "dtype": "str", 
-            "default": null, 
+            "info": "Range of frequency channels to keep (zero-based inclusive 'first_chan,last_chan', default is all channels)",
+            "dtype": "str",
+            "default": null,
             "name": "channel-range"
-        }, 
+        },
         {
-            "info": "Flag elevations outside the range 'lowest_elevation,highest_elevation'", 
-            "dtype": "str", 
-            "default": null, 
+            "info": "Flag elevations outside the range 'lowest_elevation,highest_elevation'",
+            "dtype": "str",
+            "default": null,
             "name": "elevation-range"
-        }, 
+        },
         {
-            "info": "Add MODEL_DATA and CORRECTED_DATA columns to the MS. MODEL_DATA initialised to unity amplitude zero phase, CORRECTED_DATA initialised to DATA.", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "Add MODEL_DATA and CORRECTED_DATA columns to the MS. MODEL_DATA initialised to unity amplitude zero phase, CORRECTED_DATA initialised to DATA.",
+            "dtype": "bool",
+            "default": false,
             "name": "model-data"
-        }, 
+        },
         {
-            "info": "List of online flags to apply (from 'static,cam,data_lost,ingest_rfi,cal_rfi,predicted_rfi', default is all flags, '' will apply no flags)", 
-            "dtype": "str", 
-            "default": null, 
+            "info": "List of online flags to apply (from 'static,cam,data_lost,ingest_rfi,cal_rfi,predicted_rfi', default is all flags, '' will apply no flags)",
+            "dtype": "str",
+            "default": null,
             "name": "flags"
-        }, 
+        },
         {
-            "info": "Output time averaging interval in seconds, default is no averaging.", 
-            "dtype": "float", 
-            "default": 0.0, 
+            "info": "Output time averaging interval in seconds, default is no averaging.",
+            "dtype": "float",
+            "default": 0.0,
             "name": "dumptime"
-        }, 
+        },
         {
-            "info": "Bin width for channel averaging in channels, default is no averaging", 
-            "dtype": "int", 
-            "default": 0, 
+            "info": "Bin width for channel averaging in channels, default is no averaging",
+            "dtype": "int",
+            "default": 0,
             "name": "chanbin"
-        }, 
+        },
         {
-            "info": "If a single element in an averaging bin is flagged, flag the averaged bin.", 
-            "dtype": "bool", 
-            "default": false, 
+            "info": "If a single element in an averaging bin is flagged, flag the averaged bin.",
+            "dtype": "bool",
+            "default": false,
             "name": "flagav"
         }
     ]


### PR DESCRIPTION
The single_pol branch removes the -VV and -HH arguments and adds a
--pols-to-use argument instead. As this functionality has been merged
into https://github.com/sjperkins/katdal/tree/use-python-casacore-ms-creation
we update the h5toms parameters.json file to reflect the change in
arguments.