### PR TITLE
Fix for broken inspect when building cabs.

### DIFF
--- a/stimela/__init__.py
+++ b/stimela/__init__.py
@@ -112,7 +112,7 @@ def build(argv):
 
         image = "{:s}_cab/{:s}".format(USER, cab)
 
-        docker.build(cab,
+        docker.build(image,
                      path,
                      build_args=build_args, args=no_cache)
 


### PR DESCRIPTION
Fixed by @SpheMakh  on my laptop. Incorrectly named variable was wreaking havoc. This minor change should fix it.