### PR TITLE
Build casacore with more cores

### DIFF
--- a/stimela/cargo/base/katdal/Dockerfile
+++ b/stimela/cargo/base/katdal/Dockerfile
@@ -29,7 +29,7 @@ RUN git clone --depth 1 https://github.com/sjperkins/casacore.git -b expose-reco
     mkdir -p /src/casacore/build && \
     cd /src/casacore/build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && \
-    make && \
+    make -j 16 && \
     make install && \
     cd / && \
     rm -rf /src


### PR DESCRIPTION
Should build casacore with multiple cores... could be why it times out on Dockerhub