### PR TITLE
Fixes portability issue

### DIFF
--- a/stimela/cargo/base/wsclean/Dockerfile
+++ b/stimela/cargo/base/wsclean/Dockerfile
@@ -50,7 +50,7 @@ RUN docker-apt-install $PACKAGES && \
     make install && \
     # WSClean
     cd ../../../wsclean-2.4/build && \
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=Release .. && \ 
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=Release -DPORTABLE=Yes .. && \ 
     make -j 16 && \
     make install && \
     docker-apt-install python-yaml && \


### PR DESCRIPTION
WSClean 2.4 unwisely enables native-marching by default. This should
fix the illegal instruction signal received on older machines.

Fixes #183