### PR TITLE
Upgrade WSClean to v2.5

### DIFF
--- a/stimela/cargo/base/wsclean/Dockerfile
+++ b/stimela/cargo/base/wsclean/Dockerfile
@@ -30,16 +30,16 @@ ENV PACKAGES \
 RUN docker-apt-install $PACKAGES && \
     mkdir -p /opt/src && \
     cd /opt/src && \
-    wget https://github.com/casacore/casacore/archive/v2.3.0.tar.gz && \
-    wget https://ufpr.dl.sourceforge.net/project/wsclean/wsclean-2.4/wsclean-2.4.tar.bz2 && \
+    wget https://github.com/casacore/casacore/archive/v2.4.0.tar.gz && \
+    wget https://ufpr.dl.sourceforge.net/project/wsclean/wsclean-2.5/wsclean-2.5.tar.bz2 && \
     svn co --non-interactive --no-auth-cache --username lofar-guest --password lofar-guest https://svn.astron.nl/LOFAR/tags/LOFAR-Release-2_21_9 && \
-    tar -xvf v2.3.0.tar.gz && \
-    tar -xvf wsclean-2.4.tar.bz2 && \
-    mkdir casacore-2.3.0/build && \
-    mkdir wsclean-2.4/build && \
+    tar -xvf v2.4.0.tar.gz && \
+    tar -xvf wsclean-2.5.tar.bz2 && \
+    mkdir casacore-2.4.0/build && \
+    mkdir wsclean-2.5/build && \
     mkdir -p LOFAR-Release-2_21_9/build/gnucxx11_opt && \
     # CASACORE
-    cd casacore-2.3.0/build && \
+    cd casacore-2.4.0/build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DUSE_OPENMP=YES -DUSE_FFTW3=YES -DUSE_HDF5=YES -DCMAKE_BUILD_TYPE=Release .. && \ 
     make -j 16 && \
     make install && \
@@ -49,7 +49,7 @@ RUN docker-apt-install $PACKAGES && \
     make -j16 && \
     make install && \
     # WSClean
-    cd ../../../wsclean-2.4/build && \
+    cd ../../../wsclean-2.5/build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=Release -DPORTABLE=Yes .. && \ 
     make -j 16 && \
     make install && \

--- a/stimela/cargo/cab/wsclean/Dockerfile
+++ b/stimela/cargo/cab/wsclean/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/wsclean:0.3.1
+FROM stimela/wsclean:0.3.2dev
 MAINTAINER <sphemakh@gmail.com>
 ADD src /code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -127,7 +127,7 @@
             "dtype": "bool", 
             "default": false, 
             "name": "nomfsweighting",
-            "mapping": "no-mfsweighting"
+            "mapping": "no-mfs-weighting"
         }, 
         {
             "info": "Filter the weights and set high weights to the local mean. The level parameter specifies the filter level; any value larger than level*localmean will be set to level*localmean.", 

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -370,7 +370,7 @@
             "dtype": "str", 
             "default": null, 
             "name": "column",
-            "mapping": "data-column"
+            "mapping": "datacolumn"
         }, 
         {
             "info": "Set maximum baseline distance", 

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -100,7 +100,8 @@
             "info": "Save the gridded uv plane, i.e., the FFT of the residual image. The UV plane is complex, hence two images will be output: <prefix>-uv-real.fits and <prefix>-uv-imag.fits", 
             "dtype": "bool", 
             "default": false, 
-            "name": "saveuv"
+            "name": "saveuv",
+            "mapping": "save-uv"
         }, 
         {
             "info": "Assume the visibilities have already been beam-corrected for the reference direction.", 
@@ -118,13 +119,15 @@
             "info": "Increase the weight gridding box size, similar to Casa's superuniform weighting scheme. The factor can be rational and can be less than one for subpixel weighting.", 
             "dtype": "float", 
             "default": 1.0, 
-            "name": "superweight"
+            "name": "superweight",
+            "mapping": "super-weight"
         }, 
         {
             "info": "In spectral mode, calculate the weights as if the image was made using MFS. This makes sure that the sum of channel images equals the MFS weights. Otherwise, the channel image will become a bit more naturally weighted. This is only relevant for weighting modes that require gridding (i.e., Uniform, Briggs').", 
             "dtype": "bool", 
             "default": false, 
-            "name": "nomfsweighting"
+            "name": "nomfsweighting",
+            "mapping": "no-mfsweighting"
         }, 
         {
             "info": "Filter the weights and set high weights to the local mean. The level parameter specifies the filter level; any value larger than level*localmean will be set to level*localmean.", 
@@ -210,7 +213,8 @@
             "info": "Splits the bandwidth and makes count nr. of images", 
             "dtype": "int", 
             "default": 1, 
-            "name": "channelsout"
+            "name": "channelsout",
+            "mapping": "channels-out"
         }, 
         {
             "info": "Use the minimum suggested w-layers for an image of the given size. Can e.g. be used to increase accuracy when predicting small part of full image.", 
@@ -228,13 +232,15 @@
             "info": "Perform inversion at the Nyquist resolution and upscale the image to the requested image size afterwards. This speeds up inversion considerably, but makes aliasing slightly worse. This effect is in most cases <1%", 
             "dtype": "bool", 
             "default": false, 
-            "name": "nosmallinversion"
+            "name": "nosmallinversion",
+            "mapping": "no-small-inversion"
         }, 
         {
             "info": " Kernel and mode used for gridding: kb = Kaiser-Bessel (default with 7 pixels), nn = nearest neighbour (no kernel), rect = rectangular window.", 
             "dtype": "str", 
             "default": "kb", 
-            "name": "gridmode", 
+            "name": "gridmode",
+            "mapping": "grid-mode",
             "choices": [
                 "nn", 
                 "kb", 
@@ -245,7 +251,8 @@
             "info": "Gridding antialiasing kernel size", 
             "dtype": "int", 
             "default": 7, 
-            "name": "gkernelsize"
+            "name": "gkernelsize",
+            "mapping": "kernel-size",
         }, 
         {
             "info": "Oversampling factor used during gridding", 
@@ -269,7 +276,8 @@
             "info": "Save the gridding correction image. This shows the effect of the antialiasing filter", 
             "dtype": "bool", 
             "default": false, 
-            "name": "savegridding"
+            "name": "savegridding",
+            "mapping": "save-gridding"
         }, 
         {
             "info": "Predict via a direct Fourier transform. This is slow, but can account for direction-dependent effects. This has only effect when 'mgain' is set or 'predict' is given.", 
@@ -332,13 +340,15 @@
             "info": "Number of intervals to image inside the selected global interval", 
             "dtype": "int", 
             "default": 1, 
-            "name": "intervalsout"
+            "name": "intervalsout",
+            "mapping": "intervals-out"
         }, 
         {
             "info": "Only image the given channel range. Indices specify channel indices, end index is exclusive", 
             "dtype": "list:int", 
             "default": null, 
-            "name": "channelrange"
+            "name": "channelrange",
+            "mapping": "channel-range"
         }, 
         {
             "info": "Image the given field id. Default: first field (id 0)", 
@@ -359,8 +369,8 @@
             "info": "CORRECTED_DATA if it exists, otherwise DATA will be used.", 
             "dtype": "str", 
             "default": null, 
-            "name": "column", 
-            "mapping": "datacolumn"
+            "name": "column",
+            "mapping": "data-column"
         }, 
         {
             "info": "Set maximum baseline distance", 
@@ -449,13 +459,15 @@
             "info": "Perform cleaning by searching for peaks in the sum of squares of the polarizations, but subtract components from the individual images. Only possible when imaging two or four Stokes or linear parameters", 
             "dtype": "bool", 
             "default": false, 
-            "name": "joinpolarizations"
+            "name": "joinpolarizations",
+            "mapping": "join-polarizations"
         }, 
         {
             "info": "Perform cleaning by searching for peaks in the MFS image, but subtract components from individual channels. This will turn on mfsweighting by default", 
             "dtype": "bool", 
             "default": false, 
-            "name": "joinchannels"
+            "name": "joinchannels",
+            "mapping": "join-channels"
         }, 
         {
             "info": "Clean on different scales. This is a new algorithm. This parameter invokes the v1.9 multiscale algorithm, which is slower but more accurate compared to the older algorithm, and therefore the recommended one to use. The older algorithm is now invoked with 'fast-multiscale'.", 
@@ -497,13 +509,15 @@
             "info": "Set the border size in which no cleaning is performed, in percentage of the width/height of the image. With an image size of 1000 and clean border of 1%, each border is 10 pixels.", 
             "dtype": "float", 
             "default": null, 
-            "name": "cleanborder"
+            "name": "cleanborder",
+            "mapping": "clean-border"
         }, 
         {
             "info": "Use the specified fits-file as mask during cleaning.", 
             "dtype": "file", 
             "default": null, 
-            "name": "fitsmask", 
+            "name": "fitsmask",
+            "mapping": "fits-mask",
             "io": "input"
         }, 
         {
@@ -511,25 +525,22 @@
             "dtype": "file", 
             "default": null, 
             "name": "casamask", 
+            "mapping": "casa-mask",
             "io": "input"
-        }, 
-        {
-            "info": "Resize the psf to speed up minor clean iterations", 
-            "dtype": "bool", 
-            "default": false, 
-            "name": "smallpsf"
         }, 
         {
             "info": "Do not allow negative components during cleaning", 
             "dtype": "bool", 
             "default": false, 
-            "name": "nonegative"
+            "name": "nonegative",
+            "mapping": "no-negative"
         }, 
         {
             "info": "Stop on negative components", 
             "dtype": "bool", 
             "default": false, 
-            "name": "stopnegative"
+            "name": "stopnegative",
+            "mapping": "stop-negative"
         }, 
         {
             "info": "Fit a polynomial over frequency to each clean component. This has only effect when the channels are joined with 'joinchannels'", 
@@ -559,43 +570,50 @@
             "info": "Set a circular beam size (FWHM) in arcsec for restoring the clean components.", 
             "dtype": "float", 
             "default": null, 
-            "name": "beamsize"
+            "name": "beamsize",
+            "mapping": "beam-size"
         }, 
         {
             "info": "Set the FWHM beam shape for restoring the clean components. Defaults units for maj and min are arcsec, and degrees for PA. Can be overriden, e.g. 'beamshape 1amin 1amin 3deg'. Default is use PSF FWHM sizes", 
             "dtype": "list:int", 
             "default": null, 
-            "name": "beamshape"
+            "name": "beamshape",
+            "mapping": "beam-shape"
         }, 
         {
             "info": "Determine beam shape by fitting the PSF.", 
             "dtype": "bool", 
             "default": true, 
-            "name": "fitbeam"
+            "name": "fitbeam",
+            "mapping": "fit-beam"
         }, 
         {
             "info": "Write the beam in output fits files as calculated from the longest projected baseline. This method results in slightly less accurate beam size/integrated fluxes, but provides a beam size without making the PSF for quick imaging.", 
             "dtype": "bool", 
             "default": false, 
-            "name": "theoreticbeam"
+            "name": "theoreticbeam",
+            "mapping": "theoretic-beam"
         }, 
         {
             "info": "Do not determine beam shape from the PSF", 
             "dtype": "bool", 
             "default": false, 
-            "name": "nofitbeam"
+            "name": "nofitbeam",
+            "mapping": "no-fit-beam"
         }, 
         {
             "info": "Force restoring beam to be circular", 
             "dtype": "bool", 
             "default": false, 
-            "name": "circularbeam"
+            "name": "circularbeam",
+            "mapping": "circular-beam"
         }, 
         {
             "info": "Allow restoring beam to be elliptical", 
             "dtype": "bool", 
             "default": true, 
-            "name": "ellipticalbeam"
+            "name": "ellipticalbeam",
+            "mapping": "elliptical-beam"
         }
     ]
 }

--- a/stimela/cargo/cab/wsclean/src/run.py
+++ b/stimela/cargo/cab/wsclean/src/run.py
@@ -65,6 +65,9 @@ for param in params:
         if isinstance(value, (int, float)):
             value = '{0}asec'.format(value)
 
+    if name == 'datacolumn':
+        name = 'data-column' # new interface as of WSCLEAN 2.5 - here for compat
+
     if name in 'size trim nwlayers-for-size beam-shape channel-range interval'.split():
         if isinstance(value, int):
             value = '{0} {0}'.format(value)

--- a/stimela/cargo/cab/wsclean/src/run.py
+++ b/stimela/cargo/cab/wsclean/src/run.py
@@ -14,6 +14,39 @@ cab = utils.readJson(CONFIG)
 params = cab['parameters']
 args = []
 
+# new interface as of WSCLEAN v2.5
+# make the transition transparent
+
+npix = filter(lambda x: x['name'] == 'size', params)[0]['value']
+
+if isinstance(npix, int):
+    npix = [npix, npix]
+elif isinstance(npix, list) and len(npix) == 1:
+    npix = npix * 2
+elif not (isinstance(npix, list) and
+          all([isinstance(px, int) for px in npix]) and
+          len(npix) == 2) :
+    raise ValueError("Npix only accepts single int or list[2] of int")
+
+trdefault = int(max(npix[0], npix[1]) * 0.75)
+trim = filter(lambda x: x['name'] == 'trim', params)[0]['value']
+
+if trim is None:
+    trim = [trdefault, trdefault]
+elif isinstance(trim, int):
+    trim = [trim, trim]
+elif isinstance(trim, list) and len(trim) == 1:
+    trim = trim * 2
+elif not (isinstance(trim, list) and
+          all([isinstance(t, int) for t in trim]) and
+          len(npix) == 2) :
+    raise ValueError("trim only accepts single int or list[2] of int")
+pad = max(npix[0], npix[1]) / float(min(trim[0], trim[1]))
+trindex = filter(lambda x: x['name'] == 'trim', params)[0]
+params.remove(trindex)
+filter(lambda x: x['name'] == 'size', params)[0]["value"] = trim #npix is now the unpadded size
+params.append({ 'name': 'padding', 'value': pad }) #replace with 'padding' argument
+
 for param in params:
     name = param['name']
     value = param['value']
@@ -32,7 +65,7 @@ for param in params:
         if isinstance(value, (int, float)):
             value = '{0}asec'.format(value)
 
-    if name in 'size trim nwlayers-for-size beamshape channelrange interval'.split():
+    if name in 'size trim nwlayers-for-size beam-shape channel-range interval'.split():
         if isinstance(value, int):
             value = '{0} {0}'.format(value)
         elif hasattr(value, '__iter__'):


### PR DESCRIPTION
This upgrades WSClean to version 2.5 released 2017-12-01.

Changelog:
 - Add compatibility mode for specifying padding through trim and npix
 - Add compatibility mode for changed cli argument names

Fixes #221