### PR TITLE
Update Dockerfile for Cubical

### DIFF
--- a/stimela/cargo/base/cubical/Dockerfile
+++ b/stimela/cargo/base/cubical/Dockerfile
@@ -5,7 +5,10 @@ RUN docker-apt-install casacore-dev \
         libcfitsio3-dev \
         wcslib-dev
 RUN pip install -U pip setuptools wheel
-RUN pip install cubical
+RUN docker-apt-install wget git-all
+RUN git clone https://github.com/ratt-ru/CubiCal
+RUN pip install cython numpy
+RUN cd CubiCal && python setup.py gocythonize && pip install .
 RUN pip install tensorflow==1.8.0
 RUN pip install -I git+https://github.com/ska-sa/montblanc
 ENV NUMBA_CACHE_DIR /tmp


### PR DESCRIPTION
Uses @Athanaseus 's changes to the Cubical Dockerfile to switch from the pypi version to installation from source. Gets rid of the rebinning errors.