### PR TITLE
Add chgcentre cab

### DIFF
--- a/stimela/cargo/base/chgcentre/Dockerfile
+++ b/stimela/cargo/base/chgcentre/Dockerfile
@@ -1,0 +1,36 @@
+FROM stimela/base:1.0.1
+MAINTAINER <sphemakh@gmail.com>
+RUN apt-get update
+RUN docker-apt-install cmake \
+    wget \
+    subversion \
+    build-essential \
+    cmake \
+    gfortran \
+    g++ \
+    libncurses5-dev \
+    libreadline-dev \
+    flex \
+    bison \
+    libblas-dev \
+    liblapacke-dev \
+    libcfitsio-dev \
+    libgsl-dev \
+    wcslib-dev \
+    libhdf5-serial-dev \
+    libfftw3-dev \
+    python-numpy \
+    libboost-python-dev \
+    libboost-all-dev \
+    libpython2.7-dev \
+    liblog4cplus-dev \
+    libhdf5-dev \
+    casacore-dev
+RUN wget https://sourceforge.net/projects/wsclean/files/chgcentre-1.6/chgcentre-1.6.tar.bz2
+RUN tar xvf chgcentre-1.6.tar.bz2 && cd chgcentre
+RUN mkdir chgcentre/build
+RUN cd chgcentre/build && \
+    cmake .. && \
+    make -j 10 && \
+    make install
+RUN ulimit -p 9000

--- a/stimela/cargo/cab/chgcentre/Dockerfile
+++ b/stimela/cargo/cab/chgcentre/Dockerfile
@@ -1,0 +1,5 @@
+FROM stimela/chgcentre:dev
+MAINTAINER <sphemakh@gmial.com>
+ADD src /scratch/code
+ENV LOGFILE ${OUTPUT}/logfile.txt
+CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/chgcentre/parameters.json
+++ b/stimela/cargo/cab/chgcentre/parameters.json
@@ -1,0 +1,55 @@
+{
+    "task": "chgcentre",
+    "base": "stimela/chgcentre",
+    "tag": "dev",
+    "description": "Tool used to change the phase centre of a measurement set",
+    "prefix": "-",
+    "binary": "chgcentre",
+    "msdir": true,
+    "parameters": [
+        {
+            "info": "Name of MS file to change the phase centre", 
+            "check_io": false, 
+            "name": "msname", 
+            "default": null, 
+            "dtype": "file", 
+            "required": true, 
+            "io": "msfile"
+        }, 
+        {
+            "info": "New RA to change to. The format of RA can either be 00h00m00.0s or 00:00:00.0",
+            "default": null,
+            "required": false,
+            "name": "new-ra",
+            "dtype": "str"
+        },
+        {
+            "info": "New DEC to change to. The format of DEC can either be 00h00m00.0s or 00:00:00.0",
+            "default": null,
+            "required": false,
+            "name": "new-dec",
+            "dtype": "str"
+        },
+        {
+            "info": "Rephase to the direction orthogonal to the best-fit plane to the antennas",
+            "default": null,
+            "required": false,
+            "name": "minw",
+            "dtype": "bool"
+        },
+        {
+            "info": "Rephase to the local array zenith",
+            "default": null,
+            "required": false,
+            "name": "zenith",
+            "dtype": "bool"
+        },
+        {
+            "info": "Prepare the measurement set for w-snapshot imaging with WSClean",
+            "default": null,
+            "required": false,
+            "name": "shiftback",
+            "dtype": "bool"
+        }
+    ]
+}

--- a/stimela/cargo/cab/chgcentre/src/run.py
+++ b/stimela/cargo/cab/chgcentre/src/run.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append('/scratch/stimela')
+import utils
+
+CONFIG = os.environ["CONFIG"]
+INPUT = os.environ["INPUT"]
+MSDIR = os.environ["MSDIR"]
+
+cab = utils.readJson(CONFIG)
+args = []
+
+for param in cab['parameters']:
+    name = param['name']
+    value = param['value']
+    if value is None:
+        continue
+    elif value is False:
+        continue
+
+    if value is bool:
+        args += ['{0}{1}'.format(cab['prefix'], name)]
+    else:
+        args += ['{0}'.format(value)]
+
+utils.xrun(cab['binary'], args)

--- a/stimela/cargo/cab/chgcentre/src/run.sh
+++ b/stimela/cargo/cab/chgcentre/src/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
+(exit ${PIPESTATUS[0]})


### PR DESCRIPTION
- Tool used to change the phase centre of a measurement set
* Basic run:
```
recipe.add('cab/chgcentre', "Change_phase_centre_of_ms", {
     "msname"    :  "test.ms",
     "new-ra"    :  "00:00:00.0",
     "new-dec"   :  "-31.00.00.0"
     },
     input='input',
     output='output',
label="Changing phase centre of MS")
```

Resolves #307