### PR TITLE
Add makemask cab

### DIFF
--- a/stimela/cargo/cab/casa_makemask/Dockerfile
+++ b/stimela/cargo/cab/casa_makemask/Dockerfile
@@ -1,0 +1,5 @@
+FROM stimela/casa:1.0.1
+MAINTAINER <sphemakh@gmail.com>
+ADD src /scratch/code
+ENV LOGFILE ${OUTPUT}/logfile.txt
+CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/casa_makemask/Dockerfile
+++ b/stimela/cargo/cab/casa_makemask/Dockerfile
@@ -1,5 +1,6 @@
 FROM stimela/casa:1.0.1
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
+ENV CASA_ENABLE_TELEMETRY=false
 ENV LOGFILE ${OUTPUT}/logfile.txt
 CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/casa_makemask/parameters.json
+++ b/stimela/cargo/cab/casa_makemask/parameters.json
@@ -1,0 +1,64 @@
+{
+    "task": "casa_makemask", 
+    "base": "stimela/casa", 
+    "tag": "1.0.1", 
+    "description": "Makes and manipulates image masks", 
+    "prefix": "-", 
+    "binary": "makemask", 
+    "msdir": false, 
+    "parameters": [
+        {
+            "info": "Mask method", 
+            "name": "mode", 
+            "dtype": "str", 
+            "required": true, 
+            "default": "copy", 
+            "choices": [
+                "list",
+                "copy",
+                "expand",
+                "delete",
+                "setdefaultmask"
+            ]
+        }, 
+        {
+            "info": "Name of input image", 
+            "name": "inpimage", 
+            "io": "input", 
+            "default": null, 
+            "dtype": "file", 
+            "required": true
+        }, 
+        {
+            "info": "Mask(s) to be processed: image masks,T/F internal masks(Need to include parent image", 
+            "name": "inpmask",
+            "io": "input", 
+            "default": null, 
+            "dtype": "file", 
+            "required": false
+        }, 
+        {
+            "info": "Name of output mask (imagename or imagename:internal_maskname)", 
+            "name": "output", 
+            "io": "output", 
+            "default": null, 
+            "dtype": "str", 
+            "required": true
+        }, 
+        {
+            "info": "ist with 1 or 3 elements giving the tile shape of the disk data columns", 
+            "name": "overwrite",
+            "default": false, 
+            "dtype": "bool",
+            "required": true
+           
+        }, 
+        {
+            "info": "Cut-off threshold to mask sources", 
+            "name": "threshold",
+            "dtype": "float", 
+            "default": null,
+            "required": false
+        } 
+    ]
+}

--- a/stimela/cargo/cab/casa_makemask/parameters.json
+++ b/stimela/cargo/cab/casa_makemask/parameters.json
@@ -46,7 +46,7 @@
             "required": true
         }, 
         {
-            "info": "ist with 1 or 3 elements giving the tile shape of the disk data columns", 
+            "info": "overwrite output if exists",
             "name": "overwrite",
             "default": false, 
             "dtype": "bool",

--- a/stimela/cargo/cab/casa_makemask/src/run.py
+++ b/stimela/cargo/cab/casa_makemask/src/run.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import logging
+import Crasa.Crasa as crasa
+
+sys.path.append("/scratch/stimela")
+import utils
+
+CONFIG = os.environ["CONFIG"]
+INPUT = os.environ["INPUT"]
+OUTPUT = os.environ["OUTPUT"]
+MSDIR = os.environ["MSDIR"]
+
+cab = utils.readJson(CONFIG)
+
+makemask_args = {}
+immath_args = {}
+for param in cab['parameters']:
+    name = param['name']
+    value = param['value']
+
+    if value is None:
+        continue
+
+    if name in ['threshold', 'inpimage', 'outfile']:
+        if name in ['threshold']:
+            value = ' iif( IM0 >={:f}, IM0, 0.0) '.format(value)
+            name = 'expr'
+        if name in ['outfile']:
+            value = '%s_thresh'.format(name)
+        immath_args[name] = value
+
+    if name in ['mode', 'inpimage', 'inpmask', 'output', 'overwrite']:
+    	makemask_args[name] = value
+
+task = crasa.CasaTask("immath", **immath_args)
+task.run()
+
+if 'inpmask' not in makemask_args:
+    makemask_args['inputmask'] = immath_args['outfile']
+
+task = crasa.CasaTask(cab["binary"], **makemask_args)
+task.run()

--- a/stimela/cargo/cab/casa_makemask/src/run.py
+++ b/stimela/cargo/cab/casa_makemask/src/run.py
@@ -22,22 +22,27 @@ for param in cab['parameters']:
     if value is None:
         continue
 
-    if name in ['threshold', 'inpimage', 'outfile']:
+    if name in ['threshold', 'inpimage', 'output']:
         if name in ['threshold']:
-            value = ' iif( IM0 >={:f}, IM0, 0.0) '.format(value)
-            name = 'expr'
-        if name in ['outfile']:
-            value = '%s_thresh'.format(name)
-        immath_args[name] = value
+            im_value = ' iif( IM0 >=%s, IM0, 0.0) ' % value
+            im_name = 'expr'
+        if name in ['output']:
+            im_value = '%s_thresh' % value
+            im_name = 'outfile'
+        if name in ['inpimage']:
+            im_value = value
+            im_name = 'imagename'
+        immath_args[im_name] = im_value
 
     if name in ['mode', 'inpimage', 'inpmask', 'output', 'overwrite']:
     	makemask_args[name] = value
 
-task = crasa.CasaTask("immath", **immath_args)
-task.run()
+if 'expr' in immath_args:
+    task = crasa.CasaTask("immath", **immath_args)
+    task.run()
 
 if 'inpmask' not in makemask_args:
-    makemask_args['inputmask'] = immath_args['outfile']
+    makemask_args['inpmask'] = immath_args['outfile']
 
 task = crasa.CasaTask(cab["binary"], **makemask_args)
 task.run()

--- a/stimela/cargo/cab/casa_makemask/src/run.sh
+++ b/stimela/cargo/cab/casa_makemask/src/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
+(exit ${PIPESTATUS[0]})


### PR DESCRIPTION
Added `makemask` task since casa requires it's internal casa format mask.
- `makemask` takes an internal mask as input (in casa style normally embedded in image) then produce a mask file with 0s and 1s.
- The inpmask is created using `immath` task where a threshold is used to mask off everything else below the cut-off.