### PR TITLE
Imagers' stopping threshold

### DIFF
--- a/stimela/cargo/base/casa/Dockerfile
+++ b/stimela/cargo/base/casa/Dockerfile
@@ -5,5 +5,5 @@ RUN chmod 755 /etc/init.d/xvfb
 RUN chmod 777 /var/run
 ENV DISPLAY :99
 RUN pip install -U pip 
-RUN pip install -U crasa pyyaml
+RUN pip install -U crasa pyyaml pyfits
 ENV PATH /${PATH}

--- a/stimela/cargo/base/wsclean/Dockerfile
+++ b/stimela/cargo/base/wsclean/Dockerfile
@@ -32,4 +32,5 @@ RUN cd wsclean-2.6/build && \
     cmake -DPORTABLE=Yes .. && \
     make -j 10 && \
     make install
+RUN pip install pyfits
 RUN ulimit -p 9000

--- a/stimela/cargo/cab/calibrator/parameters.json
+++ b/stimela/cargo/cab/calibrator/parameters.json
@@ -138,13 +138,13 @@
         {
             "info": "Write flags to MS", 
             "dtype": "bool", 
-            "defalt": true, 
+            "default": true,
             "name": "write-flags-to-ms"
         }, 
         {
             "info": "name of flagset to write new flags to", 
             "dtype": "str", 
-            "defalt": null, 
+            "default": null,
             "name": "write-flagset"
         }, 
         {

--- a/stimela/cargo/cab/casa_clean/Dockerfile
+++ b/stimela/cargo/cab/casa_clean/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/casa:1.0.1
+FROM stimela/casa:devel
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/casa_clean/parameters.json
+++ b/stimela/cargo/cab/casa_clean/parameters.json
@@ -517,6 +517,19 @@
             "dtype": "bool", 
             "default": false, 
             "name": "keep_casa_images"
+        },
+        {
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it will replace threshold)",
+            "dtype": "file",
+            "default": null,
+            "name": "noise_image",
+            "io": "input"
+        },
+        {
+            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided (new thresh = sigma*noise_image.std())",
+            "dtype": "float",
+            "default": 3,
+            "name": "noise_sigma"
         }
     ]
 }

--- a/stimela/cargo/cab/casa_clean/parameters.json
+++ b/stimela/cargo/cab/casa_clean/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "casa_clean", 
     "base": "stimela/casa", 
-    "tag": "1.0.1", 
+    "tag": "devel", 
     "description": "CASA Clean task. For imaging and deconvolution", 
     "prefix": "", 
     "binary": "clean", 

--- a/stimela/cargo/cab/casa_clean/src/run.py
+++ b/stimela/cargo/cab/casa_clean/src/run.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 import Crasa.Crasa as crasa
+import pyfits
 
 sys.path.append("/scratch/stimela")
 import utils
@@ -22,6 +23,17 @@ for param in cab['parameters']:
         continue
 
     args[name] = value
+
+noise_image = args.pop('noise_image', False)
+if noise_image:
+    noise_sigma = args.pop('noise_sigma')
+    noise_hdu = pyfits.open(noise_image)
+    noise_data = noise_hdu[0].data
+    noise_std = noise_data.std()
+    threshold = noise_sigma*noise_std
+    args['threshold'] = '{}Jy'.format(threshold)
+else:
+    args.pop('noise_sigma')
 
 
 prefix = args['imagename']

--- a/stimela/cargo/cab/casa_tclean/Dockerfile
+++ b/stimela/cargo/cab/casa_tclean/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/casa:1.0.1
+FROM stimela/casa:devel
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/casa_tclean/parameters.json
+++ b/stimela/cargo/cab/casa_tclean/parameters.json
@@ -615,6 +615,19 @@
                 "flatnoise", 
                 "flatsky"
             ]
+        },
+        {
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it will replace threshold)",
+            "dtype": "file",
+            "default": null,
+            "name": "noise_image",
+            "io": "input"
+        },
+        {
+            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided (new thresh = sigma*noise_image.std())",
+            "dtype": "float",
+            "default": 3,
+            "name": "noise_sigma"
         }
     ]
 }

--- a/stimela/cargo/cab/casa_tclean/parameters.json
+++ b/stimela/cargo/cab/casa_tclean/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "casa_tclean", 
     "base": "stimela/casa", 
-    "tag": "1.0.1", 
+    "tag": "devel", 
     "description": "CASA tclean task. Clean based algorithm for multi-scale and wideband image reconstruction, widefield imaging correcting for the w-term", 
     "prefix": "", 
     "binary": "tclean", 

--- a/stimela/cargo/cab/casa_tclean/src/run.py
+++ b/stimela/cargo/cab/casa_tclean/src/run.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 import Crasa.Crasa as crasa
+import pyfits
 
 sys.path.append("/scratch/stimela")
 import utils
@@ -23,6 +24,16 @@ for param in cab['parameters']:
 
     args[name] = value
 
+noise_image = args.pop('noise_image', False)
+if noise_image:
+    noise_sigma = args.pop('noise_sigma')
+    noise_hdu = pyfits.open(noise_image)
+    noise_data = noise_hdu[0].data
+    noise_std = noise_data.std()
+    threshold = noise_sigma*noise_std
+    args['threshold'] = '{}Jy'.format(threshold)
+else:
+    args.pop('noise_sigma')
 
 prefix = args['imagename']
 port2fits = args.pop('port2fits', True)
@@ -33,7 +44,7 @@ task = crasa.CasaTask(cab["binary"], **args)
 task.run()
 
 nterms = args.get("nterms", 1)
-images = ["flux", "model", "residual", "psf", "image"]
+images = ["flux", "model", "residual", "psf", "image", "mask", "pb", "sumwt"]
 STD_IMAGES = images[:4]
 
 convert = []

--- a/stimela/cargo/cab/ddfacet/parameters.json
+++ b/stimela/cargo/cab/ddfacet/parameters.json
@@ -1318,7 +1318,7 @@
         {
             "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided (new thresh = sigma*noise_image.std())",
             "dtype": "float",
-            "default": 3,
+            "default": 3.0,
             "name": "Noise-Sigma"
         }
     ]

--- a/stimela/cargo/cab/ddfacet/parameters.json
+++ b/stimela/cargo/cab/ddfacet/parameters.json
@@ -1307,6 +1307,19 @@
             "required": false, 
             "name": "Misc-RandomSeed", 
             "dtype": "int"
+        },
+        {
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it will replace Deconv-FluxThreshold)",
+            "dtype": "file",
+            "default": null,
+            "name": "Noise-Image",
+            "io": "input"
+        },
+        {
+            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided (new thresh = sigma*noise_image.std())",
+            "dtype": "float",
+            "default": 3,
+            "name": "Noise-Sigma"
         }
     ]
 }

--- a/stimela/cargo/cab/ddfacet/src/run.py
+++ b/stimela/cargo/cab/ddfacet/src/run.py
@@ -54,7 +54,7 @@ for item1 in args:
                         args.remove(item3)
                 args.append('{0}Deconv-FluxThreshold {1}'.format(cab['prefix'], threshold))
 if not removed:
-    args.remove('{0}Noise-Sigma 3'.format(cab['prefix']))
+    args.remove('{0}Noise-Sigma 3.0'.format(cab['prefix']))
 
 if parset is not None:
     args.insert(0, parset)

--- a/stimela/cargo/cab/ddfacet/src/run.py
+++ b/stimela/cargo/cab/ddfacet/src/run.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import json
+import pyfits
 
 sys.path.append("/scratch/stimela")
 import utils
@@ -22,6 +23,8 @@ for param in cab['parameters']:
         continue
     if name == 'Parset' and value is None:
         continue
+    if name == 'Noise-Image' and value is None:
+        continue
 
     if isinstance(value, list):
         arg = "{0}{1} {2}".format(cab['prefix'], name, ",".join(value))
@@ -29,6 +32,29 @@ for param in cab['parameters']:
         arg = '{0}{1} {2}'.format(cab['prefix'], name, value)
 
     args.append(arg)
+
+
+removed = False
+for item1 in args:
+    if 'Noise-Image' in item1:
+        noise_image = item1.split('{0}Noise-Image '.format(cab['prefix']))[-1]
+        args.remove('{0}Noise-Image {1}'.format(cab['prefix'], noise_image))
+        noise_hdu = pyfits.open(noise_image)
+        noise_data = noise_hdu[0].data
+        noise_std = noise_data.std()
+        noise_hdu.close()
+        for item2 in args:
+            if 'Noise-Sigma' in item2:
+                noise_sigma = item2.split('{0}Noise-Sigma '.format(cab['prefix']))[-1]
+                args.remove('{0}Noise-Sigma {1}'.format(cab['prefix'], noise_sigma))
+                removed = True
+                threshold = float(noise_sigma)*noise_std
+                for item3 in args:
+                    if '{0}Deconv-FluxThreshold'.format(cab['prefix']) in item3:
+                        args.remove(item3)
+                args.append('{0}Deconv-FluxThreshold {1}'.format(cab['prefix'], threshold))
+if not removed:
+    args.remove('{0}Noise-Sigma 3'.format(cab['prefix']))
 
 if parset is not None:
     args.insert(0, parset)

--- a/stimela/cargo/cab/lwimager/parameters.json
+++ b/stimela/cargo/cab/lwimager/parameters.json
@@ -257,6 +257,19 @@
             "name": "threshold"
         }, 
         {
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it with replace threshold)",
+            "dtype": "file",
+            "default": null,
+            "name": "noise_image",
+            "io": "input"
+        },
+        {
+            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided",
+            "dtype": "float",
+            "default": 3,
+            "name": "noise_sigma"
+        },
+        {
             "info": "Target flux for maximum entropy", 
             "dtype": [
                 "float", 

--- a/stimela/cargo/cab/lwimager/parameters.json
+++ b/stimela/cargo/cab/lwimager/parameters.json
@@ -257,14 +257,14 @@
             "name": "threshold"
         }, 
         {
-            "info": "Noise image to compute sigma for stopping threshold (in case specified it with replace threshold)",
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it will replace threshold)",
             "dtype": "file",
             "default": null,
             "name": "noise_image",
             "io": "input"
         },
         {
-            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided",
+            "info": "Noise sigma for stopping deconvolution in the case where noise_image is provided (new thresh = sigma*noise_image.std())",
             "dtype": "float",
             "default": 3,
             "name": "noise_sigma"

--- a/stimela/cargo/cab/lwimager/src/run.py
+++ b/stimela/cargo/cab/lwimager/src/run.py
@@ -156,9 +156,18 @@ for param in params:
     elif name in ['threshold', 'targetflux']:
         if isinstance(value, float):
             value = '{}arcsec'.format(value)
-
     options[name] = value
 
+noise_image = options.pop('noise_image', False)
+if noise_image:
+    noise_sigma = options.pop('noise_sigma')
+    noise_hdu = pyfits.open(noise_image)
+    noise_data = noise_hdu[0].data
+    noise_std = noise_data.std()
+    threshold = noise_sigma*noise_std
+    options['threshold'] = '{}Jy'.format(threshold)
+else:
+    options.pop('noise_sigma')
 
 predict = options.pop('simulate_fits', False)
 if predict:

--- a/stimela/cargo/cab/wsclean/Dockerfile
+++ b/stimela/cargo/cab/wsclean/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/wsclean:1.0.1
+FROM stimela/wsclean:devel
 MAINTAINER <sphemakh@gmail.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "wsclean", 
     "base": "stimela/wsclean", 
-    "tag": "1.0.1", 
+    "tag": "devel", 
     "description": "WSClean imaging software", 
     "prefix": "-", 
     "binary": "wsclean", 

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -640,6 +640,19 @@
             "default": false,
             "name": "predict",
             "mapping": "-predict"
+        },
+        {
+            "info": "Noise image to compute sigma for stopping threshold (in case specified it will replace threshold)",
+            "dtype": "file",
+            "default": null,
+            "name": "noise-image",
+            "io": "input"
+        },
+        {
+            "info": "Noise sigma for stopping deconvolution in the case where noise-image is provided (new thresh = sigma*noise_image.std())",
+            "dtype": "float",
+            "default": 3,
+            "name": "noise-sigma"
         }
     ]
 }

--- a/stimela/cargo/cab/wsclean/parameters.json
+++ b/stimela/cargo/cab/wsclean/parameters.json
@@ -651,7 +651,7 @@
         {
             "info": "Noise sigma for stopping deconvolution in the case where noise-image is provided (new thresh = sigma*noise_image.std())",
             "dtype": "float",
-            "default": 3,
+            "default": 3.0,
             "name": "noise-sigma"
         }
     ]

--- a/stimela/cargo/cab/wsclean/src/run.py
+++ b/stimela/cargo/cab/wsclean/src/run.py
@@ -114,8 +114,8 @@ if '{0}auto-threshold'.format(cab['prefix']) not in args:
                             args.remove(item3)
                     args.append('{0}threshold {1}'.format(cab['prefix'], threshold))
     if not removed:
-        args.remove('{0}noise-sigma 3'.format(cab['prefix']))
+        args.remove('{0}noise-sigma 3.0'.format(cab['prefix']))
 else:
-    args.remove('{0}noise-sigma 3'.format(cab['prefix']))
+    args.remove('{0}noise-sigma 3.0'.format(cab['prefix']))
 
 utils.xrun(cab['binary'], args + [mslist])


### PR DESCRIPTION
- Provide **optional** params (`noise_image` & `noise_sigma`) to compute the deconvolution stopping threshold. If noise image is provided, threshold = noise_sigma*noise_image.std()