### PR TITLE
Added max-chunk parameter.

### DIFF
--- a/stimela/cargo/cab/cubical/parameters.json
+++ b/stimela/cargo/cab/cubical/parameters.json
@@ -369,6 +369,12 @@
             "name": "dist-ncpu"
         }, 
         {
+            "info": "Maximum number of time/freq data-chunks to load into memory simultaneously. If 0, then as many as possible will be loaded.", 
+            "dtype": "int", 
+            "default": 0, 
+            "name": "max-chunks"
+        }, 
+        {
             "info": "Number of OMP threads to use. 0: determine automatically.",
             "name" : "dist-nthread",
             "dtype": "int"


### PR DESCRIPTION
The max-chunk parameter is needed for dealing with Singularity container images. Since Singularity does not allow for shared memory to be changed, if the data set is big enough and since max-chunk is 0 by default (load as many as possible as permitted by number of parallel processes), this causes crashes of cubical runs. Specifying max-chunks to a low number (3-4) should allow Cubical to run via Stimela when using Singularity images.