### PR TITLE
Politsiyakat fix

### DIFF
--- a/stimela/cargo/cab/politsiyakat_autocorr_amp/parameters.json
+++ b/stimela/cargo/cab/politsiyakat_autocorr_amp/parameters.json
@@ -1,5 +1,5 @@
 {
-    "task": "politsiyakat", 
+    "task": "politsiyakat_autocorr_amp", 
     "base": "stimela/politsiyakat", 
     "tag": "1.0.1", 
     "description": "Routines for automated post-1GC error detection and mitigation", 

--- a/stimela/cargo/cab/politsiyakat_cal_phase/parameters.json
+++ b/stimela/cargo/cab/politsiyakat_cal_phase/parameters.json
@@ -1,5 +1,5 @@
 {
-    "task": "politsiyakat", 
+    "task": "politsiyakat_cal_phase", 
     "base": "stimela/politsiyakat", 
     "tag": "1.0.1", 
     "description": "Routines for automated post-1GC error detection and mitigation", 


### PR DESCRIPTION
Changed the task names of politsiyakat cabs in the parameter file. This needs to be done because otherwise stimela keeps looking for a cab named "politsiyakat" instead of say "politsiyakat_cal_phase
".