### PR TITLE
Polcal47

### DIFF
--- a/Jenkinsfile.sh
+++ b/Jenkinsfile.sh
@@ -19,7 +19,7 @@ ln -s ${SINGULARITY_STORAGE}/podman ${POD_STORAGE}
 
 
 # Install Stimela into a virtual env
-virtualenv ${WORKSPACE_ROOT}/projects/pyenv -p python3.6
+virtualenv ${WORKSPACE_ROOT}/projects/pyenv
 . ${WORKSPACE_ROOT}/projects/pyenv/bin/activate
 pip install pip setuptools -U
 PATH=${WORKSPACE}/projects/pyenv/bin:$PATH

--- a/stimela/cargo/cab/casa47_polcal/Dockerfile
+++ b/stimela/cargo/cab/casa47_polcal/Dockerfile
@@ -1,0 +1,5 @@
+FROM stimela/casa:0.3.0
+MAINTAINER <sphemakh@gmail.com>
+ADD src /scratch/code
+ENV LOGFILE ${OUTPUT}/logfile.txt
+CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/casa47_polcal/parameters.json
+++ b/stimela/cargo/cab/casa47_polcal/parameters.json
@@ -1,0 +1,180 @@
+{
+    "task": "casa_polcal", 
+    "base": "stimela/casa", 
+    "tag": "0.3.0", 
+    "description": "Specify Calibration Values of Various Types", 
+    "prefix": "-", 
+    "binary": "polcal", 
+    "msdir": true, 
+    "parameters": [
+        {
+            "info": "Name of input visibility file", 
+            "dtype": "file", 
+            "required": true, 
+            "name": "vis", 
+            "io": "msfile"
+        }, 
+        {
+            "info": "Name of output gain calibration table", 
+            "dtype": "file", 
+            "default": null, 
+            "name": "caltable", 
+            "io": "output"
+        }, 
+        {
+            "info": "Select field using field id(s) or field name(s)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "field"
+        }, 
+        {
+            "info": "Select spectral window/channels", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "spw"
+        }, 
+        {
+            "info": "Other data selection parameters", 
+            "dtype": "bool", 
+            "default": true, 
+            "name": "selectdata"
+        }, 
+        {
+            "info": "Select data based on time range", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "timerange"
+        }, 
+        {
+            "info": "Select data within uvrange (default units meters)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "uvrange"
+        }, 
+        {
+            "info": "Select data based on antenna/baseline", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "antenna"
+        }, 
+        {
+            "info": "Scan number range", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "scan"
+        }, 
+        {
+            "info": "Select by observation ID(s)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "observation"
+        }, 
+        {
+            "info": "Optional complex data selection (ignore for now)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "msselect"
+        }, 
+        {
+            "info": "Solution interval: egs. 'inf', '60s' (see help)", 
+            "dtype": [
+                "str", 
+                "float", 
+                "int"
+            ], 
+            "default": "inf", 
+            "name": "solint"
+        }, 
+        {
+            "info": "Data axes which to combine for solve (obs, scan, spw, and/or field)", 
+            "dtype": "str", 
+            "default": "obs,scan", 
+            "name": "combine"
+        }, 
+        {
+            "info": "Pre-averaging interval (sec) ", 
+            "dtype": "float", 
+            "default": 300.0, 
+            "name": "preavg"
+        }, 
+        {
+            "info": "Reference antenna name(s)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "refant"
+        }, 
+        {
+            "info": "Minimum baselines _per antenna_ required for solve", 
+            "dtype": "int", 
+            "default": 4, 
+            "name": "minblperant"
+        }, 
+        {
+            "info": "Reject solutions below this SNR", 
+            "dtype": "float", 
+            "default": 3.0, 
+            "name": "minsnr"
+        }, 
+        {
+            "info": "Type of instrumental polarization solution (see help)", 
+            "dtype": "str", 
+            "default": "D+QU", 
+            "name": "poltype"
+        }, 
+        {
+            "info": "Point source Stokes parameters for source model.", 
+            "dtype": "list:float", 
+            "delimiter": ",", 
+            "name": "smodel", 
+            "default": null
+        }, 
+        {
+            "info": "Append solutions to the (existing) table", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "append"
+        }, 
+        {
+            "info": "Use callib or traditional cal apply parameters", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "docallib"
+        }, 
+        {
+            "info": "Cal Library filename", 
+            "dtype": "file", 
+            "default": null, 
+            "name": "callib", 
+            "io": "input"
+        }, 
+        {
+            "info": "Gain calibration table(s) to apply on the fly", 
+            "delimeter": ",", 
+            "name": "gaintable", 
+            "io": "input", 
+            "default": null, 
+            "dtype": "list:file"
+        }, 
+        {
+            "info": "Select a subset of calibrators from gaintable(s)", 
+            "dtype": "list:str", 
+            "default": null, 
+            "name": "gainfield", 
+            "delimeter": ","
+        }, 
+        {
+            "info": "Interpolation mode (in time) to use for each gaintable(s)", 
+            "dtype": "list:str", 
+            "default": null, 
+            "name": "interp", 
+            "delimeter": ","
+        }, 
+        {
+            "info": "Spectral windows combinations to form for gaintables(s)", 
+            "dtype": "list:int", 
+            "default": null, 
+            "name": "spwmap", 
+            "delimeter": ","
+        }
+    ]
+}

--- a/stimela/cargo/cab/casa47_polcal/src/run.py
+++ b/stimela/cargo/cab/casa47_polcal/src/run.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import drivecasa
+import logging
+casa = drivecasa.Casapy(log2term=True, echo_to_stdout=True, timeout=24*3600*10)
+
+sys.path.append("/scratch/stimela")
+
+utils = __import__('utils')
+
+CONFIG = os.environ["CONFIG"]
+INPUT = os.environ["INPUT"]
+OUTPUT = os.environ["OUTPUT"]
+MSDIR = os.environ["MSDIR"]
+
+cab = utils.readJson(CONFIG)
+
+args = {}
+for param in cab['parameters']:
+    name = param['name']
+    value = param['value']
+
+    if value is None:
+        continue
+
+    args[name] = value
+
+script = ['{0}(**{1})'.format(cab['binary'], args)]
+
+
+def log2term(result):
+    if result[1]:
+        err = '\n'.join(result[1] if result[1] else [''])
+        failed = err.lower().find('an error occurred running task') >= 0
+        if failed:
+            raise RuntimeError('CASA Task failed. See error message above')
+        sys.stdout.write('WARNING:: SEVERE messages from CASA run')
+
+
+result = casa.run_script(script, raise_on_severe=False)
+log2term(result)

--- a/stimela/cargo/cab/casa47_polcal/src/run.sh
+++ b/stimela/cargo/cab/casa47_polcal/src/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
+(exit ${PIPESTATUS[0]})

--- a/stimela/cargo/cab/casa47_setjy/Dockerfile
+++ b/stimela/cargo/cab/casa47_setjy/Dockerfile
@@ -1,0 +1,5 @@
+FROM stimela/casa:0.3.0
+MAINTAINER <sphemakh@gmail.com>
+ADD src /scratch/code
+ENV LOGFILE ${OUTPUT}/logfile.txt
+CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/casa47_setjy/parameters.json
+++ b/stimela/cargo/cab/casa47_setjy/parameters.json
@@ -1,0 +1,177 @@
+{
+    "task": "casa_setjy", 
+    "base": "stimela/casa", 
+    "tag": "3.0.0", 
+    "description": "Fills the model column with the visibilities of a calibrator", 
+    "prefix": "-", 
+    "binary": "setjy", 
+    "msdir": true, 
+    "parameters": [
+        {
+            "info": "Name of input visibility file", 
+            "name": "msname", 
+            "io": "msfile", 
+            "dtype": "file", 
+            "required": true, 
+            "mapping": "vis"
+        }, 
+        {
+            "info": "Field Name(s). Comma separated string of field IDs/names", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "field"
+        }, 
+        {
+            "info": "Spectral window identifier (list)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "spw"
+        }, 
+        {
+            "info": "Other data selection parameters", 
+            "dtype": "bool", 
+            "default": true, 
+            "name": "selectdata"
+        }, 
+        {
+            "info": "Time range to operate on (for usescratch=T)", 
+            "dtype": [
+                "str", 
+                "list:str"
+            ], 
+            "default": null, 
+            "name": "timerange"
+        }, 
+        {
+            "info": "Scan number range (for  usescratch=T)", 
+            "dtype": "list:str", 
+            "default": null, 
+            "name": "scan"
+        }, 
+        {
+            "info": "Observation ID range (for  usescratch=T)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "observation"
+        }, 
+        {
+            "info": "Observation intent", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "intent"
+        }, 
+        {
+            "info": "scale the flux density on a per channel basis or else on a per spw basis", 
+            "dtype": "bool", 
+            "default": true, 
+            "name": "scalebychan"
+        }, 
+        {
+            "info": "Flux density standard", 
+            "dtype": "str", 
+            "default": "Perley-Butler 2010", 
+            "name": "standard", 
+            "choices": [
+                "Perley-Butler 2010", 
+                "Perley-Butler 2013", 
+                "Baars", 
+                "Perley 90", 
+                "Perley-Taylor 95", 
+                "Perley-Taylor 99", 
+                "Scaife-Heald 2012", 
+                "Stevens-Reynolds 2016", 
+                "Butler-JPL-Horizons 2010", 
+                "Butler-JPL-Horizons 2012", 
+                "manual", 
+                "fluxscale"
+            ]
+        }, 
+        {
+            "info": "method to be used to interpolate in time", 
+            "dtype": "str", 
+            "default": "linear", 
+            "name": "interpolation", 
+            "choices": [
+                "nearest", 
+                "linear", 
+                "cubic", 
+                "spline"
+            ]
+        }, 
+        {
+            "info": "use directions in the ephemeris table", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "useephemdir"
+        }, 
+        {
+            "info": "Specified flux density [I,Q,U,V]; (-1 will lookup values)", 
+            "dtype": "list:float", 
+            "default": null, 
+            "name": "fluxdensity"
+        }, 
+        {
+            "info": "Spectral index of fluxdensity", 
+            "dtype": [
+                "float", 
+                "list:float", 
+                "int", 
+                "list:int"
+            ], 
+            "default": 0.0, 
+            "name": "spix"
+        }, 
+        {
+            "info": "Polarization index of calibrator (taylor expansion modelling frequency dependence, first of which is ratio of sqrt(Q^2+U^2)/I). Auto determined if Q and U are non-zero in fluxdensity option. See NRAO docs.", 
+            "dtype": [
+                "float", 
+                "list:float", 
+                "int", 
+                "list:int"
+            ], 
+            "default": [], 
+            "name": "polindex"
+        }, 
+        {
+            "info": "Polarization angle (rads) of calibrator (taylor expansion modelling frequency dependence, first of which is 0.5*arctan(U/Q). Should be specified in combination with polindex option. Ignored if fluxdensity specified non-zero coefficients for Q and U. See NRAO docs.", 
+            "dtype": [
+                "float", 
+                "list:float", 
+                "int", 
+                "list:int"
+            ], 
+            "default": [], 
+            "name": "polangle"
+        }, 
+        {
+            "info": "Reference frequency for spix", 
+            "dtype": "str", 
+            "default": "1GHz", 
+            "name": "reffreq"
+        }, 
+        {
+            "info": "output dictionary from fluxscale(NB: this is a dictionary)", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "fluxdict"
+        }, 
+        {
+            "info": "List the available modimages for VLA calibrators or Tb models for Solar System objects", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "listmodels"
+        }, 
+        {
+            "info": "File location for field model", 
+            "dtype": "str", 
+            "default": null, 
+            "name": "model"
+        }, 
+        {
+            "info": "Will create if necessary and use the MODEL_DATA", 
+            "dtype": "bool", 
+            "default": false, 
+            "name": "usescratch"
+        }
+    ]
+}

--- a/stimela/cargo/cab/casa47_setjy/src/run.py
+++ b/stimela/cargo/cab/casa47_setjy/src/run.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import drivecasa
+import logging
+casa = drivecasa.Casapy(log2term=True, echo_to_stdout=True, timeout=24*3600*10)
+
+sys.path.append("/scratch/stimela")
+
+utils = __import__('utils')
+
+CONFIG = os.environ["CONFIG"]
+INPUT = os.environ["INPUT"]
+OUTPUT = os.environ["OUTPUT"]
+MSDIR = os.environ["MSDIR"]
+
+cab = utils.readJson(CONFIG)
+
+args = {}
+for param in cab['parameters']:
+    name = param['name']
+    value = param['value']
+
+    if value is None:
+        continue
+
+    args[name] = value
+
+script = ['{0}(**{1})'.format(cab['binary'], args)]
+
+
+def log2term(result):
+    if result[1]:
+        err = '\n'.join(result[1] if result[1] else [''])
+        failed = err.lower().find('an error occurred running task') >= 0
+        if failed:
+            raise RuntimeError('CASA Task failed. See error message above')
+        sys.stdout.write('WARNING:: SEVERE messages from CASA run')
+
+
+result = casa.run_script(script, raise_on_severe=False)
+log2term(result)

--- a/stimela/cargo/cab/casa47_setjy/src/run.sh
+++ b/stimela/cargo/cab/casa47_setjy/src/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
+(exit ${PIPESTATUS[0]})

--- a/stimela/cargo/cab/docker_run
+++ b/stimela/cargo/cab/docker_run
@@ -3,6 +3,4 @@ set -e
 set -u
 /etc/init.d/xvfb start || echo "Virtual frame buffer not installed. You may not be able to plot with this cab" 
 python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
-EXIT_STAT=${PIPESTATUS[0]}
-/etc/init.d/xvfb stop || echo ""
-exit $EXIT_STAT
+/etc/init.d/xvfb stop || echo "Virtual frame buffer not started initially, because it is not installed. If you had plotting in this cab it may not have worked correctly"

--- a/stimela/cargo/cab/docker_run
+++ b/stimela/cargo/cab/docker_run
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 set -u
-/etc/init.d/xvfb start 
+/etc/init.d/xvfb start || echo "Virtual frame buffer not installed. You may not be able to plot with this cab" 
 python /scratch/code/run.py 2>&1 | tee -a $LOGFILE 
 EXIT_STAT=${PIPESTATUS[0]}
-/etc/init.d/xvfb stop
+/etc/init.d/xvfb stop || echo ""
 exit $EXIT_STAT

--- a/stimela/cargo/cab/singularity_run
+++ b/stimela/cargo/cab/singularity_run
@@ -7,6 +7,4 @@ export CONFIG=/scratch/configfile
 export MSDIR=/scratch/msdir
 /etc/init.d/xvfb start || echo "Virtual frame buffer not installed. You may not be able to plot with this cab" 
 python /scratch/code/run.py 2>&1 | tee -a /scratch/logfile 
-EXIT_STAT=${PIPESTATUS[0]}
-/etc/init.d/xvfb stop || echo ""
-(exit ${PIPESTATUS[0]})
+/etc/init.d/xvfb stop || echo "Virtual frame buffer not started because it is not installed, if you had plots in this cab it may not have worked correctly."

--- a/stimela/cargo/cab/singularity_run
+++ b/stimela/cargo/cab/singularity_run
@@ -5,5 +5,8 @@ export INPUT=/scratch/input
 export OUTPUT=/scratch/output
 export CONFIG=/scratch/configfile
 export MSDIR=/scratch/msdir
-python /scratch/code/run.py 2>&1 | tee -a /scratch/logfile
+/etc/init.d/xvfb start || echo "Virtual frame buffer not installed. You may not be able to plot with this cab" 
+python /scratch/code/run.py 2>&1 | tee -a /scratch/logfile 
+EXIT_STAT=${PIPESTATUS[0]}
+/etc/init.d/xvfb stop || echo ""
 (exit ${PIPESTATUS[0]})

--- a/stimela/cargo/cab/tricolour/Dockerfile
+++ b/stimela/cargo/cab/tricolour/Dockerfile
@@ -1,5 +1,7 @@
-FROM stimela/tricolour:1.1.3
+FROM stimela/tricolour:1.2.1
 MAINTAINER <sphemakh@gmial.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt
+RUN rm /usr/bin/python
+RUN ln /usr/bin/python3 /usr/bin/python
 CMD /scratch/code/run.sh

--- a/stimela/cargo/cab/tricolour/Dockerfile
+++ b/stimela/cargo/cab/tricolour/Dockerfile
@@ -1,4 +1,4 @@
-FROM stimela/tricolour:1.2.0
+FROM stimela/tricolour:1.1.3
 MAINTAINER <sphemakh@gmial.com>
 ADD src /scratch/code
 ENV LOGFILE ${OUTPUT}/logfile.txt

--- a/stimela/cargo/cab/tricolour/parameters.json
+++ b/stimela/cargo/cab/tricolour/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "tricolour", 
     "base": "stimela/tricolour", 
-    "tag": "1.1.3", 
+    "tag": "1.2.1", 
     "description": "A variant of the Science Data Processing flagging code, wrapped in dask, operating on Measurement Sets", 
     "prefix": "--", 
     "binary": "/opt/code/dist/tricolourexe/tricolourexe", 

--- a/stimela/cargo/cab/tricolour/parameters.json
+++ b/stimela/cargo/cab/tricolour/parameters.json
@@ -1,7 +1,7 @@
 {
     "task": "tricolour", 
     "base": "stimela/tricolour", 
-    "tag": "1.2.0", 
+    "tag": "1.1.3", 
     "description": "A variant of the Science Data Processing flagging code, wrapped in dask, operating on Measurement Sets", 
     "prefix": "--", 
     "binary": "/opt/code/dist/tricolourexe/tricolourexe", 


### PR DESCRIPTION
- Fixes xvfb for singularity runner
- Fixes cases where xvfb is not available (should not be compulsory, esp. for older cabs)
- Adds polcal from CASA 4.7 (stimela 3.0.0)