### PR TITLE
Makes invert-uvw ON by default.

### DIFF
--- a/stimela/cargo/cab/crystalball/parameters.json
+++ b/stimela/cargo/cab/crystalball/parameters.json
@@ -41,7 +41,7 @@
         {
             "info": "Optional. Invert UVW coordinates. Useful if we want compare our visibilities against MeqTrees", 
             "dtype": "bool", 
-            "default": false, 
+            "default": true, 
             "name": "invert-uvw"
         }, 
         {


### PR DESCRIPTION
Switched on invert-uvw parameter in Crystalball by default to make the uvw convention the same as meqtrees, wsclean, CASA etc.